### PR TITLE
chore: extend setup info and lockdown requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 data.zip
 upload.zip
 .idea
+venv

--- a/README.md
+++ b/README.md
@@ -1,26 +1,66 @@
 # About
-This script is used to synchronize staging and production emx2 data catalogues. 
-1. It extracts OntologyTerms from the staging area and loads them to the production catalogue. 
-2. It extracts cohort variable metadata from emx2 staging databases, transforms the datamodel and loads the data to
-to production catalogue.
-3. It extracts network variable metadata from emx2 staging databases and loads them to the production catalogue.
-4. It extracts the catalogue from production and loads the networks' (or models') variable metadata to the staging 
-catalogue (containing only the common data models).
+This script is used to synchronize staging area and data catalogues. 
+1. It extracts OntologyTerms from the staging area and loads them to the catalogue. 
+2. It extracts cohort variable metadata from staging area, transforms the datamodel and loads the data to
+to catalogue.
+3. It extracts network variable metadata from staging area and loads them to the catalogue.
+4. It extracts the model from catalogues and loads the networks' (or models') variable metadata to the staging 
+area (containing only the common data models).
 
 # System requirements
-Python 3 (3.8.6)
+- Python 3 (3.8.6)
 
-create a virtual env 
+- Git
 
-pip install pandas==1.1.3
-pip install numpy==1.19.2
-pip install requests==2.21.0
+# Initial one-time setup for running the transform script
 
-# Set up details
-Edit global variables (UPPER_CASE) in run.py to set up 
-details for staging and production server.
+Use virtual env to get a consistent python environment.
+Initially you need to set up the virtual python environment.
 
-# Run script
-run.py
+1. Clone the github repository
+
+`git clone git@github.com:molgenis/molgenis-py-catalogue-transform.git`
+
+`cd molgenis-py-catalogue-transform.git`
+
+2. Create a virtual python environment
+
+`python -m venv venv` 
+
+3. Activate the virtual python environment
+
+`source venv/bin/activate`
+
+4. Install the script dependencies from requirements.txt file
+
+`pip install -r requirements.txt`
+
+More info see:
+
+mac: https://www.youtube.com/watch?v=Kg1Yvry_Ydk
+
+window: https://www.youtube.com/watch?v=APOPm01BVrk
+
+# Running the script using the virtual python virtual environment
+1. Activate the virtual python environment
+
+`source venv/bin/activate`
+
+(1.1 Optionally update the requirements)
+
+`pip install -r requirements.txt`
+
+(1.2 Optionally configure the script by updating the global variables (UPPER_CASE) in run.py to set up 
+details for staging and production server.)
+
+2. Run the script
+
+`python run.py`
+
+3. deactivate the the virtual python environment
+
+`deactivate`
+# For script developers
+Make sure to update the requirements.txt file is requirements change ( added , removed, version change ...)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+certifi==2021.5.30
+chardet==3.0.4
+idna==2.8
+numpy==1.21.1
+pandas==1.1.3
+python-dateutil==2.8.2
+pytz==2021.1
+requests==2.21.0
+six==1.16.0
+urllib3==1.24.3


### PR DESCRIPTION
- Extend info about using virtual env as run enviroment
- Lockdown requirements, and add note about using requirements.txt to readme
- Use consistent nameing when referencing stating of catalog in readme file